### PR TITLE
[bitstamp] Public websockets api

### DIFF
--- a/rust/ccx/api/bitstamp/src/api/mod.rs
+++ b/rust/ccx/api/bitstamp/src/api/mod.rs
@@ -11,8 +11,9 @@ use crate::client::RateLimiter;
 use crate::client::RateLimiterBucket;
 use crate::client::RateLimiterBucketMode;
 use crate::client::RestClient;
-// use crate::client::WebsocketStream;
+use crate::client::WebsocketStream;
 use crate::client::CCX_BITSTAMP_API_PREFIX;
+use crate::BitstampResult;
 
 pub const API_BASE: &str = "https://www.bitstamp.net/api/v2/";
 pub const STREAM_BASE: &str = "wss://ws.bitstamp.net";
@@ -104,11 +105,8 @@ mod with_network {
                 (API_BASE, STREAM_BASE)
             };
             let api_base = Url::parse(api_base).unwrap();
-            let _stream_base = Url::parse(stream_base).unwrap();
-            Api::with_config(Config::new(
-                signer, api_base, /* , _stream_base */
-                proxy,
-            ))
+            let stream_base = Url::parse(stream_base).unwrap();
+            Api::with_config(Config::new(signer, api_base, stream_base, proxy))
         }
 
         pub fn with_config(config: Config<S>) -> Self {
@@ -134,10 +132,10 @@ mod with_network {
                 rate_limiter,
             }
         }
-        //
-        //     /// Creates multiplexed websocket stream.
-        //     pub async fn ws(&self) -> BitstampResult<WebsocketStream> {
-        //         self.client.web_socket().await
-        //     }
+
+        /// Creates multiplexed websocket stream.
+        pub async fn ws(&self) -> BitstampResult<WebsocketStream> {
+            self.client.web_socket().await
+        }
     }
 }

--- a/rust/ccx/api/bitstamp/src/api/order/types/mod.rs
+++ b/rust/ccx/api/bitstamp/src/api/order/types/mod.rs
@@ -1,9 +1,9 @@
 mod market_order;
 mod open_order;
-mod order_status;
 mod order_id;
+mod order_status;
 
 pub use market_order::*;
 pub use open_order::*;
-pub use order_status::*;
 pub use order_id::*;
+pub use order_status::*;

--- a/rust/ccx/api/bitstamp/src/client/config.rs
+++ b/rust/ccx/api/bitstamp/src/client/config.rs
@@ -74,7 +74,7 @@ pub static CCX_BITSTAMP_API_PREFIX: &str = "CCX_BITSTAMP_API";
 pub struct Config<S: BitstampSigner> {
     pub signer: S,
     pub api_base: Url,
-    // pub stream_base: Url,
+    pub stream_base: Url,
     pub proxy: Option<Proxy>,
     // pub tier: RateLimiterTier,
 }
@@ -86,14 +86,14 @@ where
     pub fn new(
         signer: S,
         api_base: Url,
-        // stream_base: Url,
+        stream_base: Url,
         proxy: Option<Proxy>,
         // tier: RateLimiterTier,
     ) -> Self {
         Config {
             signer,
             api_base,
-            // stream_base,
+            stream_base,
             proxy,
             // tier,
         }

--- a/rust/ccx/api/bitstamp/src/client/mod.rs
+++ b/rust/ccx/api/bitstamp/src/client/mod.rs
@@ -2,8 +2,10 @@ mod config;
 mod rate_limiter;
 mod rest;
 mod signer;
+mod websocket;
 
 pub use config::*;
 pub use rate_limiter::*;
 pub use rest::*;
 pub use signer::*;
+pub use websocket::*;

--- a/rust/ccx/api/bitstamp/src/client/rest.rs
+++ b/rust/ccx/api/bitstamp/src/client/rest.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::client::*;
 // use crate::client::limits::UsedRateLimits;
-// use crate::client::WebsocketStream;
+use crate::client::WebsocketStream;
 use crate::error::*;
 // use crate::proto::TimeWindow;
 
@@ -105,11 +105,11 @@ where
     pub fn delete(&self, endpoint: &str) -> BitstampResult<RequestBuilder<S>> {
         self.request(Method::DELETE, endpoint)
     }
-    //
-    // pub async fn web_socket(&self) -> BitstampResult<WebsocketStream> {
-    //     let url = self.inner.config.stream_base.clone();
-    //     Ok(WebsocketStream::connect(self.clone(), url).await?)
-    // }
+
+    pub async fn web_socket(&self) -> BitstampResult<WebsocketStream> {
+        let url = self.inner.config.stream_base.clone();
+        Ok(WebsocketStream::connect(self.clone(), url).await?)
+    }
 }
 
 impl<S> RequestBuilder<S>

--- a/rust/ccx/api/bitstamp/src/client/websocket.rs
+++ b/rust/ccx/api/bitstamp/src/client/websocket.rs
@@ -1,0 +1,306 @@
+use std::collections::HashMap;
+use std::io;
+use std::time::{Duration, Instant};
+
+use actix::io::SinkWrite;
+use actix::prelude::*;
+use actix_codec::Framed;
+use actix_http::ws::Codec;
+use actix_web_actors::ws;
+use awc::BoxedSocket;
+use futures::channel::mpsc;
+use futures::stream::SplitSink;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::client::RestClient;
+use crate::error::{BitstampError, BitstampResult};
+/*
+use crate::ws_stream::UpstreamApiRequest;
+use crate::ws_stream::UpstreamWebsocketMessage;
+*/
+use crate::ws_stream::{Event, SystemEvent, WsCommand, WsEvent, WsSubscription};
+
+/// How often heartbeat pings are sent.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+/// How long before lack of client response causes a timeout.
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Interval between automatic reconnections.
+///
+/// According to documentation every connection older than 90 days will be
+/// automatically dropped.
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+#[derive(actix::Message, Clone, Debug, Serialize, Deserialize)]
+#[rtype(result = "()")]
+struct M<T>(pub T);
+
+#[derive(actix::Message, Clone, Debug)]
+#[rtype(result = "()")]
+struct ReconnectSocket;
+
+pub struct WebsocketStream {
+    tx: WebsocketStreamTx,
+    rx: mpsc::UnboundedReceiver<WsEvent>,
+}
+
+pub struct WebsocketStreamTx {
+    addr: Addr<Websocket>,
+}
+
+pub struct Websocket {
+    api_client: awc::Client,
+    ws_url: Url,
+    tx: mpsc::UnboundedSender<WsEvent>,
+
+    channels: HashMap<WsSubscription, bool>,
+
+    inner: Option<InnerSocket>,
+}
+
+struct InnerSocket {
+    sink: SinkWrite<ws::Message, SplitSink<Framed<BoxedSocket, Codec>, ws::Message>>,
+    hb: Instant,
+}
+
+impl Actor for Websocket {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.hb(ctx);
+    }
+}
+
+/// Handler for `ws::Message`.
+impl StreamHandler<Result<ws::Frame, ws::ProtocolError>> for Websocket {
+    fn handle(&mut self, msg: Result<ws::Frame, ws::ProtocolError>, ctx: &mut Self::Context) {
+        let msg = match msg {
+            Ok(msg) => msg,
+            Err(e) => {
+                log::warn!("WebSocket broken: {:?}", e);
+                ctx.stop();
+                return;
+            }
+        };
+
+        match msg {
+            ws::Frame::Ping(msg) => {
+                self.inner_mut().hb = Instant::now();
+                if let Err(_msg) = self.inner_mut().sink.write(ws::Message::Pong(msg)) {
+                    log::warn!("Failed to send Pong. Disconnecting.");
+                    ctx.stop()
+                }
+            }
+            ws::Frame::Pong(_) => {
+                self.inner_mut().hb = Instant::now();
+            }
+            ws::Frame::Binary(_bin) => {
+                log::warn!("unexpected binary message (ignored)");
+            }
+            ws::Frame::Text(msg) => {
+                let res = serde_json::from_slice(&msg);
+                if res.is_err() {
+                    log::error!(
+                        "json message from server: {}",
+                        String::from_utf8_lossy(&msg)
+                    );
+                }
+
+                let event = match res {
+                    Err(e) => {
+                        log::error!("Failed to deserialize server message: {:?}", e);
+                        return;
+                    }
+                    Ok(msg) => msg,
+                };
+
+                match event {
+                    Event::Client(ev) => {
+                        if let Err(e) = self.tx.unbounded_send(ev) {
+                            log::warn!("Failed to notify downstream: {:?}", e);
+                            ctx.stop()
+                        }
+                    }
+                    Event::System(ev) => match ev {
+                        SystemEvent::ReconnectRequest => {
+                            log::debug!("Reconnect request received");
+                            ctx.notify(ReconnectSocket);
+                        }
+                        SystemEvent::SubscriptionSucceeded { channel } => {
+                            let subscription = channel.into();
+                            if !self.channels.contains_key(&subscription) {
+                                log::warn!(
+                                    "Successfully subscribed to {:?}. But it was \
+                                         not found in list of active subscriptions",
+                                    subscription,
+                                );
+                            }
+                            self.channels.insert(subscription, true);
+                        }
+                        SystemEvent::Error { channel, data } => {
+                            log::error!(
+                                "Websocket Channel({}) returned error: {:?}",
+                                channel,
+                                data
+                            );
+                        }
+                        SystemEvent::Heartbeat => {}
+                    },
+                }
+            }
+            ws::Frame::Close(_) => {
+                ctx.stop();
+            }
+            ws::Frame::Continuation(_) => {
+                ctx.stop();
+            }
+        }
+    }
+}
+
+impl actix::io::WriteHandler<ws::ProtocolError> for Websocket {}
+
+impl Handler<M<WsCommand>> for Websocket {
+    type Result = ();
+
+    fn handle(&mut self, M(cmd): M<WsCommand>, ctx: &mut Self::Context) {
+        let msg = serde_json::to_string(&cmd).expect("json encode");
+        log::debug!("Sending to server: `{}`", msg);
+        if let Err(_) = self.inner_mut().sink.write(ws::Message::Text(msg.into())) {
+            ctx.stop();
+        }
+
+        match cmd {
+            WsCommand::Subscribe(cmd) => {
+                self.channels.entry(cmd).or_default();
+            }
+            WsCommand::Unsubscribe(cmd) => {
+                self.channels.remove(&cmd);
+            }
+        };
+    }
+}
+
+impl Handler<ReconnectSocket> for Websocket {
+    type Result = ResponseActFuture<Self, ()>;
+
+    fn handle(&mut self, _: ReconnectSocket, _: &mut Self::Context) -> Self::Result {
+        use futures::StreamExt as _;
+
+        let api_client = self.api_client.clone();
+        let ws_url = self.ws_url.clone();
+
+        let fut = async move { api_client.ws(ws_url.as_str()).connect().await };
+        let fut = fut.into_actor(self).then(|res, act, ctx| {
+            let (resp, connection) = match res {
+                Ok((resp, connection)) => (resp, connection),
+                Err(err) => {
+                    log::error!("Socket connection was not initialized: {}", err);
+                    ctx.stop();
+                    return fut::ready(());
+                }
+            };
+            log::debug!("Websocket response: {:?}", resp);
+            let (sink, stream) = connection.split();
+
+            ctx.add_stream(stream);
+            act.inner = Some(InnerSocket {
+                sink: SinkWrite::new(sink, ctx),
+                hb: Instant::now(),
+            });
+
+            // Resubscribe to previous subscriptions.
+            let old_subscriptions = std::mem::take(&mut act.channels);
+            for (subscription, _) in old_subscriptions {
+                ctx.notify(M(WsCommand::Subscribe(subscription)));
+            }
+
+            fut::ready(())
+        });
+        Box::pin(fut)
+    }
+}
+
+impl Websocket {
+    pub fn new(client: awc::Client, url: Url, tx: mpsc::UnboundedSender<WsEvent>) -> Self {
+        Self {
+            api_client: client,
+            ws_url: url,
+            tx,
+            channels: HashMap::new(),
+            inner: None,
+        }
+    }
+
+    fn inner_mut(&mut self) -> &mut InnerSocket {
+        self.inner.as_mut().expect("Uninitialized")
+    }
+
+    /// helper method that sends ping to client every second.
+    ///
+    /// also this method checks heartbeats from client
+    fn hb(&mut self, ctx: &mut <Self as Actor>::Context) {
+        ctx.run_interval(HEARTBEAT_INTERVAL, move |act, ctx| {
+            if Instant::now().duration_since(act.inner_mut().hb) > CLIENT_TIMEOUT {
+                log::warn!("Websocket client heartbeat failed, disconnecting!");
+                ctx.stop();
+                return;
+            }
+            if let Err(_msg) = act.inner_mut().sink.write(ws::Message::Ping("".into())) {
+                log::warn!("Websocket client failed to send ping, stopping!");
+                ctx.stop()
+            };
+        });
+
+        ctx.run_interval(RECONNECT_INTERVAL, move |_, ctx| {
+            ctx.notify(ReconnectSocket);
+        });
+    }
+}
+
+impl WebsocketStream {
+    pub async fn connect<S: crate::client::BitstampSigner>(
+        api_client: RestClient<S>,
+        url: Url,
+    ) -> BitstampResult<Self> {
+        log::debug!("Connecting WS: {}", url.as_str());
+
+        let client = api_client.client();
+
+        let (tx, rx) = mpsc::unbounded();
+
+        // Initialize new socket and reconnect.
+        let addr = Websocket::new(client, url, tx).start();
+        addr.send(ReconnectSocket)
+            .await
+            .map_err(|_| BitstampError::IoError(io::ErrorKind::ConnectionAborted.into()))?;
+
+        let tx = WebsocketStreamTx { addr };
+        Ok(WebsocketStream { tx, rx })
+    }
+
+    pub fn split(self) -> (WebsocketStreamTx, mpsc::UnboundedReceiver<WsEvent>) {
+        (self.tx, self.rx)
+    }
+}
+
+impl std::ops::Deref for WebsocketStream {
+    type Target = WebsocketStreamTx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
+}
+
+impl WebsocketStreamTx {
+    pub async fn subscribe_one(
+        &self,
+        subscription: impl Into<WsSubscription>,
+    ) -> BitstampResult<()> {
+        let cmd = WsCommand::Subscribe(subscription.into());
+        self.addr
+            .send(M(cmd))
+            .await
+            .map_err(|_e| BitstampError::IoError(io::ErrorKind::ConnectionAborted.into()))
+    }
+}

--- a/rust/ccx/api/bitstamp/src/proto/mod.rs
+++ b/rust/ccx/api/bitstamp/src/proto/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod ws_stream;

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/detail_order_book.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/detail_order_book.rs
@@ -1,0 +1,77 @@
+use rust_decimal::Decimal;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DetailOrderBookEvent {
+    pub timestamp: String,
+    pub microtimestamp: String,
+    pub bids: Vec<DetailOrderBookEntry>,
+    pub asks: Vec<DetailOrderBookEntry>,
+}
+
+/// Minimalistic representation of event occurred in Order Book. Received from
+/// [Live detail order book] subscription.
+///
+/// ## Deserialization:
+/// Deserialized via `(Decimal, Decimal, String)` because Bitstamp sends each
+/// event as a list of exactly three strings with decimals encoded in first two.
+/// First value represents `price`, second value represents `amount` and third
+/// value represents `order_id`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(from = "(Decimal, Decimal, String)")]
+pub struct DetailOrderBookEntry {
+    /// Unique order identifier.
+    pub order_id: String,
+    /// Price ordered.
+    pub price: Decimal,
+    /// Amount ordered.
+    pub amount: Decimal,
+}
+
+impl From<(Decimal, Decimal, String)> for DetailOrderBookEntry {
+    fn from(value: (Decimal, Decimal, String)) -> Self {
+        Self {
+            order_id: value.2,
+            price: value.0,
+            amount: value.1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ws_stream::Event;
+
+    #[test]
+    fn test_deserialize() {
+        let json = r#"{
+            "data":{
+                "timestamp":"1692095753",
+                "microtimestamp":"1692095753831370",
+                "bids":[
+                    ["29376","1.42905047", "1"],
+                    ["29375","0.70644900", "2"],
+                    ["29373","0.20000000", "3"],
+                    ["29372","0.52500000", "4"],
+                    ["29371","0.15000000", "5"]
+                ],
+                "asks":[
+                    ["29377","0.09638168", "6"],
+                    ["29378","0.00222701", "7"],
+                    ["29379","0.09643274", "8"],
+                    ["29380","0.05000000", "9"],
+                    ["29381","2.98042494", "10"]
+                ]
+            },
+            "channel":"detail_order_book_btcusd",
+            "event":"data"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize detail_order_book event: {:?}",
+            res
+        );
+    }
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/live_order.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/live_order.rs
@@ -1,0 +1,145 @@
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LiveOrderEvent {
+    /// Order ID.
+    pub id: u64,
+
+    /// Order amount.
+    pub amount: Decimal,
+    // pub amount_str: Decimal,
+    /// Order price.
+    pub price: Decimal,
+    // pub price_str: Decimal,
+    /// Order type (0 - buy; 1 - sell).
+    pub order_type: u8,
+
+    /// Order datetime.
+    pub datetime: String,
+
+    /// Order action timestamp represented microseconds.
+    pub microtimestamp: String,
+
+    /// Order amount that already had been filled.
+    pub amount_traded: Decimal,
+
+    /// Original order amount at the moment it was created.
+    pub amount_at_create: Decimal,
+
+    /// Type of this [`LiveOrderEvent`].
+    #[serde(default)]
+    pub event_type: LiveOrderEventType,
+}
+
+/// Event types related to orders.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum LiveOrderEventType {
+    #[serde(rename = "order_created")]
+    OrderCreated,
+    #[serde(rename = "order_changed")]
+    OrderChanged,
+    #[serde(rename = "order_deleted")]
+    OrderDeleted,
+    /// Fallback event type used in cases of new/unknown events.
+    #[serde(other)]
+    Unknown,
+}
+
+impl Default for LiveOrderEventType {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::ws_stream::{Event, WsEvent};
+
+    #[test]
+    fn test_order_created() {
+        let json = r#"
+            {
+                "data":{
+                    "id":1651478886379522,
+                    "id_str":"1651478886379522",
+                    "order_type":0,
+                    "datetime":"1692028062",
+                    "microtimestamp":"1692028062152000",
+                    "amount":0.34,
+                    "amount_str":"0.34000000",
+                    "amount_traded":"0",
+                    "amount_at_create":"0.34000000",
+                    "price":29422,
+                    "price_str":"29422"
+                },
+                "channel":"live_orders_btcusd",
+                "event":"order_created"
+            }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize order_created: {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn test_order_changed() {
+        let json = r#"{
+            "data":{
+                "id":1651483095416833,
+                "id_str":"1651483095416833",
+                "order_type":0,
+                "datetime":"1692029091",
+                "microtimestamp":"1692029090635000",
+                "amount":0.04944669,
+                "amount_str":"0.04944669",
+                "amount_traded":"0.00055331",
+                "amount_at_create":"0.05000000",
+                "price":29591,
+                "price_str":"29591"
+            },
+            "channel":"live_orders_btcusd",
+            "event":"order_changed"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize order_changed: {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn test_order_deleted() {
+        let json = r#"{
+            "data":{
+                "id":1651483074093058,
+                "id_str":"1651483074093058",
+                "order_type":1,
+                "datetime":"1692029085",
+                "microtimestamp":"1692029085457000",
+                "amount":0.5,
+                "amount_str":"0.50000000",
+                "amount_traded":"0",
+                "amount_at_create":"0.50000000",
+                "price":29599,
+                "price_str":"29599"
+            },
+            "channel":"live_orders_btcusd",
+            "event":"order_deleted"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize order_deleted: {:?}",
+            res
+        );
+    }
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/live_trade.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/live_trade.rs
@@ -1,0 +1,55 @@
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LiveTradeEvent {
+    /// Trade unique ID.
+    pub id: u64,
+
+    /// Trade amount.
+    pub amount: Decimal,
+    // amount_str: Decimal,
+    /// Trade price.
+    pub price: Decimal,
+    // price_str: Decimal,
+    /// Trade type (0 - buy; 1 - sell)
+    pub r#type: u8,
+
+    /// Trade mictotimestamp.
+    pub microtimestamp: String,
+
+    /// Trade buy order ID
+    pub buy_order_id: u64,
+
+    /// Trade sell order ID
+    pub sell_order_id: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ws_stream::Event;
+
+    #[test]
+    fn test_deserialize() {
+        let json = r#"
+        {
+            "data":{
+                "id":296045814,
+                "timestamp":"1692025525",
+                "amount":0.01611591,
+                "amount_str":"0.01611591",
+                "price":29452,
+                "price_str":"29452",
+                "type":1,
+                "microtimestamp":"1692025525441000",
+                "buy_order_id":1651468495040514,
+                "sell_order_id":1651468496011265
+            },
+            "channel":"live_trades_btcusd",
+            "event":"trade"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(res.is_ok(), "Failed to deserialize: {:?}", res);
+    }
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/mod.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/mod.rs
@@ -1,0 +1,139 @@
+mod detail_order_book;
+mod live_order;
+mod live_trade;
+mod order_book;
+mod request;
+mod response;
+
+use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
+
+pub use self::{
+    detail_order_book::*, live_order::*, live_trade::*, order_book::*, request::*, response::*,
+};
+
+/// Represents subscription to certain `channel`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct WsSubscription {
+    #[serde(with = "channel")]
+    pub(crate) channel: (WsStream, Atom),
+}
+
+impl WsSubscription {
+    /// Constructs new [`WsSubscription`] from [`WsStream`] and pair name.
+    pub fn new(stream: WsStream, pair: impl Into<Atom>) -> Self {
+        WsSubscription {
+            channel: (stream, pair.into()),
+        }
+    }
+}
+
+impl<A> From<(WsStream, A)> for WsSubscription
+where
+    A: Into<Atom>,
+{
+    fn from((stream, pair): (WsStream, A)) -> Self {
+        WsSubscription::new(stream, pair)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum WsStream {
+    LiveTrades,
+    LiveOrders,
+    OrderBook,
+    DetailOrderBook,
+    DiffOrderBook,
+}
+
+impl WsStream {
+    const LIVE_TRADES: &'static str = "live_trades";
+    const LIVE_ORDERS: &'static str = "live_orders";
+    const ORDER_BOOK: &'static str = "order_book";
+    const DETAIL_ORDER_BOOK: &'static str = "detail_order_book";
+    const DIFF_ORDER_BOOK: &'static str = "diff_order_book";
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WsStream::LiveTrades => Self::LIVE_TRADES,
+            WsStream::LiveOrders => Self::LIVE_ORDERS,
+            WsStream::OrderBook => Self::ORDER_BOOK,
+            WsStream::DetailOrderBook => Self::DETAIL_ORDER_BOOK,
+            WsStream::DiffOrderBook => Self::DIFF_ORDER_BOOK,
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        Some(match s {
+            Self::LIVE_TRADES => Self::LiveTrades,
+            Self::LIVE_ORDERS => Self::LiveOrders,
+            Self::ORDER_BOOK => Self::OrderBook,
+            Self::DETAIL_ORDER_BOOK => Self::DetailOrderBook,
+            Self::DIFF_ORDER_BOOK => Self::DiffOrderBook,
+            _ => None?,
+        })
+    }
+}
+
+fn channel_from_raw(value: &str) -> Option<(WsStream, Atom)> {
+    let n = value.rfind('_')?;
+    let stream = WsStream::from_str(&value[..n])?;
+    let pair = value[n + 1..].into();
+    Some((stream, pair))
+}
+
+mod channel {
+    use std::fmt;
+
+    use serde::{
+        de::{self, Visitor},
+        Deserializer, Serializer,
+    };
+
+    use super::{Atom, WsStream};
+
+    pub(super) fn serialize<S>(pair: &(WsStream, Atom), serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}_{}", pair.0.as_str(), &pair.1))
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<(WsStream, Atom), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(WsSubscriptionVisitor)
+    }
+
+    struct WsSubscriptionVisitor;
+
+    impl<'de> Visitor<'de> for WsSubscriptionVisitor {
+        type Value = (WsStream, Atom);
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string in format {channel_name}_{pair}")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            super::channel_from_raw(value)
+                .ok_or_else(|| E::custom(format!("unrecognized input: {}", value)))
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            self.visit_str(&value)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/order_book.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/order_book.rs
@@ -1,0 +1,109 @@
+use rust_decimal::Decimal;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct OrderBookEvent {
+    pub timestamp: String,
+    pub microtimestamp: String,
+    pub bids: Vec<OrderBookEntry>,
+    pub asks: Vec<OrderBookEntry>,
+}
+
+/// Minimalistic representation of event occurred in Order Book. Received from
+/// [Live order book] and [Live full order book] subscriptions. If you also need
+/// order id, please check [`DetailOrderBookEvent`].
+///
+/// ## Deserialization:
+/// Deserialized via `[Decimal; 2]` because Bitstamp sends each event as a
+/// list of exactly two strings with decimals encoded in them. First string
+/// represents `price` and the second one represents `amount`.
+///
+/// [`DetailOrderBookEvent`]: super::detail_order_book::DetailOrderBookEvent
+#[derive(Clone, Debug, Deserialize)]
+#[serde(from = "[Decimal; 2]")]
+pub struct OrderBookEntry {
+    /// Price ordered.
+    pub price: Decimal,
+    /// Amount ordered.
+    pub amount: Decimal,
+}
+
+impl From<[Decimal; 2]> for OrderBookEntry {
+    fn from(value: [Decimal; 2]) -> Self {
+        Self {
+            price: value[0],
+            amount: value[1],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ws_stream::Event;
+
+    #[test]
+    fn test_deserialize_order_book() {
+        let json = r#"{
+            "data":{
+                "timestamp":"1692095753",
+                "microtimestamp":"1692095753831370",
+                "bids":[
+                    ["29376","1.42905047"],
+                    ["29375","0.70644900"],
+                    ["29373","0.20000000"],
+                    ["29372","0.52500000"],
+                    ["29371","0.15000000"]
+                ],
+                "asks":[
+                    ["29377","0.09638168"],
+                    ["29378","0.00222701"],
+                    ["29379","0.09643274"],
+                    ["29380","0.05000000"],
+                    ["29381","2.98042494"]
+                ]
+            },
+            "channel":"order_book_btcusd",
+            "event":"data"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize order_book_event: {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn test_deserialize_order_book_diff() {
+        let json = r#"{
+            "data":{
+                "timestamp":"1692095753",
+                "microtimestamp":"1692095753831370",
+                "bids":[
+                    ["29376","1.42905047"],
+                    ["29375","0.70644900"],
+                    ["29373","0.20000000"],
+                    ["29372","0.52500000"],
+                    ["29371","0.15000000"]
+                ],
+                "asks":[
+                    ["29377","0.09638168"],
+                    ["29378","0.00222701"],
+                    ["29379","0.09643274"],
+                    ["29380","0.05000000"],
+                    ["29381","2.98042494"]
+                ]
+            },
+            "channel":"diff_order_book_btcusd",
+            "event":"data"
+        }"#;
+
+        let res = serde_json::from_str::<Event>(json);
+        assert!(
+            res.is_ok(),
+            "Failed to deserialize order_book_diff_event: {:?}",
+            res
+        );
+    }
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/request.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/request.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+use super::WsSubscription;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+#[serde(tag = "event", content = "data")]
+pub enum WsCommand {
+    #[serde(rename = "bts:subscribe")]
+    Subscribe(WsSubscription),
+    #[serde(rename = "bts:unsubscribe")]
+    Unsubscribe(WsSubscription),
+}

--- a/rust/ccx/api/bitstamp/src/proto/ws_stream/response.rs
+++ b/rust/ccx/api/bitstamp/src/proto/ws_stream/response.rs
@@ -1,0 +1,196 @@
+use derive_more::{Display, Error, From};
+use serde::Deserialize;
+
+use crate::ws_stream::{channel_from_raw, LiveOrderEventType};
+use crate::Atom;
+
+use super::{DetailOrderBookEvent, LiveOrderEvent, LiveTradeEvent, OrderBookEvent, WsStream};
+
+/// Internal type of event returned from bitstamp subscription.
+#[derive(Clone, Debug, Deserialize, From)]
+#[serde(try_from = "InnerEvent")]
+pub(crate) enum Event {
+    System(SystemEvent),
+    Client(WsEvent),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct InnerEvent {
+    event: EventType,
+    #[serde(default)]
+    channel: String,
+    #[serde(default)]
+    data: serde_json::Value,
+}
+
+impl TryFrom<InnerEvent> for Event {
+    type Error = DeserializeError;
+
+    fn try_from(value: InnerEvent) -> Result<Self, Self::Error> {
+        Ok(match value.event {
+            EventType::System(ev) => SystemEvent::try_new(ev, value.channel, value.data)?.into(),
+            EventType::Client(ev) => WsEvent::try_new(ev, value.channel, value.data)?.into(),
+        })
+    }
+}
+
+/// Wrapper to distinct between protocol\system events and actual data.
+#[derive(Clone, Debug, From, Deserialize)]
+#[serde(untagged)]
+enum EventType {
+    /// Events used by the control flow.
+    ///
+    /// Such events start with prefix `"bts:"`.
+    System(SystemEventType),
+    /// Events that should be exposed to the end consumer.
+    Client(ClientEventType),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) enum ClientEventType {
+    #[serde(rename = "data")]
+    Data,
+    #[serde(rename = "order_created")]
+    OrderCreated,
+    #[serde(rename = "order_changed")]
+    OrderChanged,
+    #[serde(rename = "order_deleted")]
+    OrderDeleted,
+    #[serde(rename = "trade")]
+    Trade,
+}
+
+/// Actual data returned from bitstamp websockets that may be interesting to the
+/// end user.
+#[derive(Clone, Debug)]
+pub enum WsEvent {
+    LiveTrade {
+        pair: Atom,
+        data: LiveTradeEvent,
+    },
+    LiveOrders {
+        pair: Atom,
+        data: LiveOrderEvent,
+    },
+    OrderBook {
+        pair: Atom,
+        data: OrderBookEvent,
+    },
+    DetailOrderBook {
+        pair: Atom,
+        data: DetailOrderBookEvent,
+    },
+    DiffOrderBook {
+        pair: Atom,
+        data: OrderBookEvent,
+    },
+}
+
+impl WsEvent {
+    pub(crate) fn try_new(
+        ev: ClientEventType,
+        channel: String,
+        data: serde_json::Value,
+    ) -> Result<Self, DeserializeError> {
+        let (stream, pair) = channel_from_raw(&channel)
+            .ok_or_else(|| DeserializeError::InvalidChannelName(channel))?;
+        let event = match (ev, stream) {
+            (ClientEventType::Data, WsStream::OrderBook) => WsEvent::OrderBook {
+                pair,
+                data: serde_json::from_value(data)?,
+            },
+            (ClientEventType::Data, WsStream::DiffOrderBook) => WsEvent::DiffOrderBook {
+                pair,
+                data: serde_json::from_value(data)?,
+            },
+            (ClientEventType::Data, WsStream::DetailOrderBook) => WsEvent::DetailOrderBook {
+                pair,
+                data: serde_json::from_value(data)?,
+            },
+            (ClientEventType::OrderCreated, WsStream::LiveOrders) => {
+                let mut event: LiveOrderEvent = serde_json::from_value(data)?;
+                event.event_type = LiveOrderEventType::OrderCreated;
+                WsEvent::LiveOrders { pair, data: event }
+            }
+            (ClientEventType::OrderChanged, WsStream::LiveOrders) => {
+                let mut event: LiveOrderEvent = serde_json::from_value(data)?;
+                event.event_type = LiveOrderEventType::OrderChanged;
+                WsEvent::LiveOrders { pair, data: event }
+            }
+            (ClientEventType::OrderDeleted, WsStream::LiveOrders) => {
+                let mut event: LiveOrderEvent = serde_json::from_value(data)?;
+                event.event_type = LiveOrderEventType::OrderDeleted;
+                WsEvent::LiveOrders { pair, data: event }
+            }
+            (ev, stream) => return Err(DeserializeError::InvalidEventAndChannel(ev, stream)),
+        };
+
+        Ok(event)
+    }
+}
+
+/// Complete set of system event types.
+#[derive(Clone, Debug, Deserialize)]
+enum SystemEventType {
+    #[serde(rename = "bts:heartbeat")]
+    Heartbeat,
+    #[serde(rename = "bts:request_reconnect")]
+    ReconnectRequest,
+    #[serde(rename = "bts:subscription_succeeded")]
+    SubscriptionSucceeded,
+    #[serde(rename = "bts:error")]
+    Error,
+}
+
+/// Complete set of system events with corresponding data.
+#[derive(Clone, Debug)]
+pub(crate) enum SystemEvent {
+    Heartbeat,
+    ReconnectRequest,
+    SubscriptionSucceeded { channel: (WsStream, Atom) },
+    Error { channel: String, data: WsError },
+}
+
+impl SystemEvent {
+    fn try_new(
+        ev: SystemEventType,
+        channel: String,
+        data: serde_json::Value,
+    ) -> Result<Self, DeserializeError> {
+        let event = match ev {
+            SystemEventType::Heartbeat => Self::Heartbeat,
+            SystemEventType::ReconnectRequest => Self::ReconnectRequest,
+            SystemEventType::SubscriptionSucceeded => {
+                let channel = channel_from_raw(&channel)
+                    .ok_or_else(|| DeserializeError::InvalidChannelName(channel))?;
+                Self::SubscriptionSucceeded { channel }
+            }
+            SystemEventType::Error => Self::Error {
+                channel,
+                data: serde_json::from_value(data)?,
+            },
+        };
+
+        Ok(event)
+    }
+}
+
+/// Error returned but Bitstamp through websockets.
+#[derive(Clone, Debug, Deserialize)]
+pub struct WsError {
+    #[serde(default)]
+    pub code: Option<i64>,
+    #[serde(default)]
+    pub message: String,
+}
+
+/// Deserialization Error for Event
+#[derive(Debug, Display, Error, From)]
+pub(crate) enum DeserializeError {
+    Serde(serde_json::Error),
+    #[display(fmt = "Invalid channel")]
+    #[from(ignore)]
+    InvalidChannelName(#[error(not(source))] String),
+    #[display(fmt = "Invalid combination of `event`: {:?} and `stream`:{:?}", _0, _1)]
+    InvalidEventAndChannel(ClientEventType, WsStream),
+}

--- a/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/account.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/account.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::CoinbaseAccountId;
 use crate::Atom;

--- a/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/account_id.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/account_id.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/generate_account.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/account_coinbase/types/generate_account.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::Atom;

--- a/rust/ccx/api/coinbase/src/api/exchange/order/types/order_side.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/order/types/order_side.rs
@@ -1,7 +1,9 @@
-use crate::api::exchange::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::exchange::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/exchange/order/types/order_time_in_force.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/order/types/order_time_in_force.rs
@@ -1,7 +1,9 @@
-use crate::api::exchange::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::exchange::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/exchange/order/types/order_type.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/order/types/order_type.rs
@@ -1,7 +1,9 @@
-use crate::api::exchange::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::exchange::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/exchange/product/types/product_status.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/product/types/product_status.rs
@@ -1,7 +1,9 @@
-use crate::api::exchange::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::exchange::prelude::*;
 
 ///
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]

--- a/rust/ccx/api/coinbase/src/api/exchange/transfer/types/fee_estimate.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/transfer/types/fee_estimate.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::Decimal;
 

--- a/rust/ccx/api/coinbase/src/api/exchange/transfer/types/mod.rs
+++ b/rust/ccx/api/coinbase/src/api/exchange/transfer/types/mod.rs
@@ -1,11 +1,11 @@
+mod fee_estimate;
 mod requested_withdrawal_to_address;
 mod transfer;
 mod transfer_details;
 mod transfer_type;
-mod fee_estimate;
 
+pub use fee_estimate::*;
 pub use requested_withdrawal_to_address::*;
 pub use transfer::*;
 pub use transfer_details::*;
 pub use transfer_type::*;
-pub use fee_estimate::*;

--- a/rust/ccx/api/coinbase/src/api/prime/mod.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/mod.rs
@@ -49,10 +49,11 @@ pub use with_network::*;
 
 #[cfg(feature = "with_network")]
 mod with_network {
+    use ccx_api_lib::env_var_with_prefix;
+
     use super::*;
     use crate::client::CoinbasePrimeSigner;
     use crate::client::PrimeRateLimiterBuilder;
-    use ccx_api_lib::env_var_with_prefix;
 
     #[derive(Clone)]
     pub struct PrimeApi<S: CoinbasePrimeSigner = PrimeApiCred> {

--- a/rust/ccx/api/coinbase/src/api/prime/order/types/order.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/order/types/order.rs
@@ -1,7 +1,8 @@
 use crate::api::prime::prelude::*;
+use crate::api::prime::PortfolioOrderSide;
 use crate::api::prime::PortfolioOrderStatus;
+use crate::api::prime::PortfolioOrderTimeInForce;
 use crate::api::prime::PortfolioOrderType;
-use crate::api::prime::{PortfolioOrderSide, PortfolioOrderTimeInForce};
 use crate::dt_coinbase::DtCoinbase;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/rust/ccx/api/coinbase/src/api/prime/order/types/order_side.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/order/types/order_side.rs
@@ -1,7 +1,9 @@
-use crate::api::prime::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::prime::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/prime/order/types/order_status.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/order/types/order_status.rs
@@ -1,7 +1,9 @@
-use crate::api::prime::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::prime::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/prime/order/types/order_time_in_force.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/order/types/order_time_in_force.rs
@@ -1,7 +1,9 @@
-use crate::api::prime::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::prime::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/prime/order/types/order_type.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/order/types/order_type.rs
@@ -1,7 +1,9 @@
-use crate::api::prime::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::prime::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_balance.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_balance.rs
@@ -1,10 +1,12 @@
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "db")]
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::Atom;
 use crate::Decimal;
-
-#[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
 
 /// List all portfolios for which the current API key has read access. (Currently, an API key
 /// is scoped to only one portfolio).

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_commission.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_commission.rs
@@ -1,5 +1,6 @@
 use derive_more::Deref;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::Atom;
 use crate::Decimal;

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_credit.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_credit.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::dt_coinbase::DtCoinbase;

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_details.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_details.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_info.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_info.rs
@@ -1,5 +1,6 @@
 use derive_more::Deref;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::PortfolioDetails;
 

--- a/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_list.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/portfolio/types/portfolio_list.rs
@@ -1,5 +1,6 @@
 use derive_more::Deref;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::PortfolioDetails;
 

--- a/rust/ccx/api/coinbase/src/api/prime/wallet/types/wallet_type.rs
+++ b/rust/ccx/api/coinbase/src/api/prime/wallet/types/wallet_type.rs
@@ -1,7 +1,9 @@
-use crate::api::prime::prelude::*;
-
 #[cfg(feature = "db")]
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::AsExpression;
+#[cfg(feature = "db")]
+use diesel_derives::FromSqlRow;
+
+use crate::api::prime::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "db", derive(AsExpression, FromSqlRow))]

--- a/rust/ccx/api/coinbase/src/client/config/exchange.rs
+++ b/rust/ccx/api/coinbase/src/client/config/exchange.rs
@@ -1,9 +1,9 @@
-use url::Url;
-
-use crate::client::CoinbaseExchangeSigner;
 use ccx_api_lib::env_var_with_prefix;
 pub use ccx_api_lib::ExchangeApiCred;
 pub use ccx_api_lib::Proxy;
+use url::Url;
+
+use crate::client::CoinbaseExchangeSigner;
 
 pub static CCX_COINBASE_EXCHANGE_API_PREFIX: &str = "CCX_COINBASE_EXCHANGE_API";
 

--- a/rust/ccx/api/coinbase/src/client/config/prime.rs
+++ b/rust/ccx/api/coinbase/src/client/config/prime.rs
@@ -1,9 +1,9 @@
-use url::Url;
-
-use crate::client::CoinbasePrimeSigner;
 use ccx_api_lib::env_var_with_prefix;
 pub use ccx_api_lib::PrimeApiCred;
 pub use ccx_api_lib::Proxy;
+use url::Url;
+
+use crate::client::CoinbasePrimeSigner;
 
 pub static CCX_COINBASE_PRIME_API_PREFIX: &str = "CCX_COINBASE_PRIME_API";
 

--- a/rust/ccx/api/coinbase/src/client/config/trade.rs
+++ b/rust/ccx/api/coinbase/src/client/config/trade.rs
@@ -1,9 +1,9 @@
-use url::Url;
-
-use crate::client::CoinbaseTradeSigner;
 use ccx_api_lib::env_var_with_prefix;
 pub use ccx_api_lib::ApiCred;
 pub use ccx_api_lib::Proxy;
+use url::Url;
+
+use crate::client::CoinbaseTradeSigner;
 
 pub static CCX_COINBASE_TRADE_API_PREFIX: &str = "CCX_COINBASE_TRADE_API";
 

--- a/rust/ccx/api/coinbase/src/client/rate_limiter/bucket.rs
+++ b/rust/ccx/api/coinbase/src/client/rate_limiter/bucket.rs
@@ -1,4 +1,5 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use crate::client::RateLimiterBucketMode;
 
@@ -53,19 +54,19 @@ impl RateLimiterBucket {
                     self.time_instant = Instant::now();
                     self.amount = 0;
                 }
-            } // RateLimiterBucketMode::CoinbaseDecrease => {
-              //     let elapsed = Instant::now().duration_since(self.time_instant);
-              //     let available =
-              //         (elapsed.as_secs_f32() / self.interval.as_secs_f32()).floor() as u32;
-              //     if available > 0 {
-              //         self.time_instant = Instant::now();
-              //         self.amount = if self.amount > available {
-              //             self.amount - available
-              //         } else {
-              //             0
-              //         };
-              //     }
-              // }
+            } /* RateLimiterBucketMode::CoinbaseDecrease => {
+               *     let elapsed = Instant::now().duration_since(self.time_instant);
+               *     let available =
+               *         (elapsed.as_secs_f32() / self.interval.as_secs_f32()).floor() as u32;
+               *     if available > 0 {
+               *         self.time_instant = Instant::now();
+               *         self.amount = if self.amount > available {
+               *             self.amount - available
+               *         } else {
+               *             0
+               *         };
+               *     }
+               * } */
         }
     }
 

--- a/rust/ccx/api/coinbase/src/client/rate_limiter/limiter/exchange.rs
+++ b/rust/ccx/api/coinbase/src/client/rate_limiter/limiter/exchange.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use actix::clock::sleep;
 use futures::channel::mpsc;

--- a/rust/ccx/api/coinbase/src/client/rate_limiter/limiter/prime.rs
+++ b/rust/ccx/api/coinbase/src/client/rate_limiter/limiter/prime.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use actix::clock::sleep;
 use futures::channel::mpsc;

--- a/rust/ccx/api/coinbase/src/client/rate_limiter/mod.rs
+++ b/rust/ccx/api/coinbase/src/client/rate_limiter/mod.rs
@@ -8,6 +8,8 @@ mod task_builder;
 mod task_message;
 mod task_metadata;
 
+use std::borrow::Cow;
+
 #[allow(unused_imports)]
 pub use bucket::*;
 #[allow(unused_imports)]
@@ -23,8 +25,6 @@ use task_builder::*;
 use task_message::*;
 #[allow(unused_imports)]
 pub use task_metadata::*;
-
-use std::borrow::Cow;
 
 type BucketName = Cow<'static, str>;
 

--- a/rust/ccx/api/coinbase/src/client/rate_limiter/task.rs
+++ b/rust/ccx/api/coinbase/src/client/rate_limiter/task.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::Context;
+use std::task::Poll;
 
 use futures::FutureExt;
 

--- a/rust/ccx/api/coinbase/src/client/rest/prime.rs
+++ b/rust/ccx/api/coinbase/src/client/rest/prime.rs
@@ -2,18 +2,19 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use actix_http::encoding::Decoder;
+use actix_http::BoxedPayloadStream;
+use actix_http::Payload;
 use actix_http::Uri;
-use actix_http::{BoxedPayloadStream, Payload};
 use awc::http::Method;
 use awc::http::StatusCode;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
 use ccx_api_lib::make_client;
 use ccx_api_lib::Client;
 use ccx_api_lib::ClientRequest;
 use ccx_api_lib::ClientResponse;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde::Serialize;
+use uuid::Uuid;
 
 use crate::client::*;
 // use crate::client::limits::UsedRateLimits;

--- a/rust/ccx/api/coinbase/src/client/signer/exchange.rs
+++ b/rust/ccx/api/coinbase/src/client/signer/exchange.rs
@@ -52,8 +52,10 @@ impl CoinbaseExchangeSigner for ExchangeApiCred {
 }
 
 fn sign(secret: &[u8], timestamp: u32, method: &str, url_path: &str, json_payload: &str) -> String {
-    use base64::{engine::general_purpose, Engine as _};
-    use hmac::{Hmac, Mac};
+    use base64::engine::general_purpose;
+    use base64::Engine as _;
+    use hmac::Hmac;
+    use hmac::Mac;
     use sha2::Sha256;
 
     let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("HMAC can take key of any size");

--- a/rust/ccx/api/coinbase/src/client/signer/prime.rs
+++ b/rust/ccx/api/coinbase/src/client/signer/prime.rs
@@ -52,8 +52,10 @@ impl CoinbasePrimeSigner for PrimeApiCred {
 }
 
 fn sign(secret: &str, timestamp: u32, method: &str, url_path: &str, json_payload: &str) -> String {
-    use base64::{engine::general_purpose, Engine as _};
-    use hmac::{Hmac, Mac};
+    use base64::engine::general_purpose;
+    use base64::Engine as _;
+    use hmac::Hmac;
+    use hmac::Mac;
     use sha2::Sha256;
 
     let mut mac =

--- a/rust/ccx/api/coinbase/src/client/signer/trade.rs
+++ b/rust/ccx/api/coinbase/src/client/signer/trade.rs
@@ -46,7 +46,8 @@ impl CoinbaseTradeSigner for ApiCred {
 }
 
 fn sign(secret: &str, timestamp: u32, method: &str, url_path: &str, json_payload: &str) -> String {
-    use hmac::{Hmac, Mac};
+    use hmac::Hmac;
+    use hmac::Mac;
     use sha2::Sha256;
 
     let mut mac =

--- a/rust/ccx/api/coinbase/src/error.rs
+++ b/rust/ccx/api/coinbase/src/error.rs
@@ -2,9 +2,8 @@ use std::borrow::Cow;
 use std::fmt;
 
 use awc::http::StatusCode;
-use thiserror::Error;
-
 pub use ccx_api_lib::*;
+use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]
 pub enum ApiErrorKind {

--- a/rust/ccx/api/coinbase/src/lib.rs
+++ b/rust/ccx/api/coinbase/src/lib.rs
@@ -13,7 +13,6 @@ pub mod util;
 pub use self::error::*;
 pub use self::proto::*;
 pub use self::util::*;
-
 #[cfg(feature = "with_network")]
 pub use self::with_network::*;
 


### PR DESCRIPTION
This commit adds support for non-private websocket subscriptions for Bitstamp.
Additionally: fixed formatting with `cargo +nightly fmt --all`
