### PR TITLE
[binance-pay] Extend response for `/v2/order`

### DIFF
--- a/rust/ccx/api/binance-pay/src/api/create_order_v2.rs
+++ b/rust/ccx/api/binance-pay/src/api/create_order_v2.rs
@@ -83,6 +83,17 @@ pub struct V2OrderResult {
     // universalUrl	string	Y	maximum length 512	universal url to finish the payment
     #[serde(rename = "universalUrl")]
     pub universal_url: String,
+    // currency	string	Y	-	order currency
+    pub currency: String,
+    // totalFee decimal(.8)	Y	-	order total amount
+    #[serde(rename = "totalFee")]
+    pub total_fee: Decimal,
+    // iatCurrency	string	N	-	order fiat currency, only return when create in fiat
+    #[serde(default, rename = "fiatCurrency")]
+    pub fiat_currency: Option<String>,
+    // fiatAmount	decimal(.8)	N	-	order fiat amount ,only return when create in fiat
+    #[serde(default, rename = "fiatAmount")]
+    pub fiat_amount: Option<Decimal>,
 }
 
 impl<S: crate::client::BinancePaySigner> Api<S> {
@@ -146,7 +157,9 @@ mod tests {
               "qrContent": "https://qrservice.dev.com/en/qr/dplk12121112b",
               "checkoutUrl": "https://pay.binance.com/checkout/dplk12121112b",
               "deeplink": "bnc://app.binance.com/payment/secpay/xxxxxx",
-              "universalUrl": "https://app.binance.com/payment/secpay?_dp=xxx=&linkToken=xxx"
+              "universalUrl": "https://app.binance.com/payment/secpay?_dp=xxx=&linkToken=xxx",
+              "totalFee": "25.17",
+              "currency": "USDT"
             },
             "errorMessage": ""
         }


### PR DESCRIPTION
This commit adds missing fields in `/binancepay/openapi/v2/order` response according to documentation