### PR TITLE
Added additional deposit statuses

### DIFF
--- a/rust/ccx/api/binance/src/api/spot/wallet.rs
+++ b/rust/ccx/api/binance/src/api/spot/wallet.rs
@@ -121,7 +121,9 @@ pub struct DepositAddress {
 pub enum DepositStatus {
     Pending = 0,
     Success = 1,
+    Rejected = 2,
     Processing = 6,
+    WrongDeposit = 7,
     WaitingForConfirmation = 8,
 }
 


### PR DESCRIPTION
Возможны ситуации когда от Binance-а приходит статус, не учтенный в вариантах enum. Это приводит к ошибке сериализации.