### PR TITLE
[Gate] temp fix for `/spot/currencies` request

### DIFF
--- a/crates/gate/src/api/spot/currency.rs
+++ b/crates/gate/src/api/spot/currency.rs
@@ -51,7 +51,7 @@ pub struct Currency {
     pub fixed_rate: Option<Decimal>,
     /// Chain of currency
     #[serde(default)]
-    pub chain: SmartString,
+    pub chain: Option<SmartString>,
 }
 
 #[cfg(feature = "with_network")]

--- a/crates/gate/src/api/spot/currency.rs
+++ b/crates/gate/src/api/spot/currency.rs
@@ -50,6 +50,7 @@ pub struct Currency {
     #[serde(default, with = "crate::util::maybe_str")]
     pub fixed_rate: Option<Decimal>,
     /// Chain of currency
+    #[serde(default)]
     pub chain: SmartString,
 }
 


### PR DESCRIPTION
Temporary fix for missing `chain` parameter in `/spot/currencies`